### PR TITLE
Remove modulo on hours in reports

### DIFF
--- a/core/formatter.go
+++ b/core/formatter.go
@@ -99,7 +99,7 @@ func (f *Formatter) RecordKey(record *Record) string {
 // seconds information is ignored.
 func (f *Formatter) FormatDuration(duration time.Duration) string {
 
-	hours := int64(duration.Hours()) % 60
+	hours := int64(duration.Hours())
 	minutes := int64(duration.Minutes()) % 60
 	dec := duration.Minutes() / 60
 	var response string


### PR DESCRIPTION
`timetrace` doesn't report days, and even if it did, the modulo should be 24, not 60. This almost caused me a heart attack! 😆